### PR TITLE
Avoid scientific notation in plot axis labels

### DIFF
--- a/R/syntax.R
+++ b/R/syntax.R
@@ -658,15 +658,20 @@ finalizePlotSyntax <- function(
     # Mirror autoscalePlotBreaks(): at the 500px default plot size it targets
     # floor(500 / 80) = 6 breaks on the (always continuous) y axis, and
     # floor(500 / 120) = 4 on a continuous x axis. Merge into an existing scale
-    # (e.g. pareto's sec.axis y scale) rather than overwriting it.
+    # (e.g. pareto's sec.axis y scale) rather than overwriting it. Labels are
+    # set explicitly because scales::breaks_pretty() often lands on round
+    # powers of ten (e.g. 100000), which trips base R's format() into
+    # scientific notation for the whole axis.
     yBreaks <- list(fun_name = "scales::breaks_pretty", args = list(n = 6))
+    numberLabels <- list(fun_name = "scales::label_number", args = list(big.mark = ""))
     if (is.null(call_list$scale_y_continuous)) {
         call_list$scale_y_continuous <- list(
             fun = ggplot2::scale_y_continuous,
-            args = list(breaks = yBreaks)
+            args = list(breaks = yBreaks, labels = numberLabels)
         )
     } else {
         call_list$scale_y_continuous$args$breaks <- yBreaks
+        call_list$scale_y_continuous$args$labels <- numberLabels
     }
 
     if (continuousX) {
@@ -674,10 +679,11 @@ finalizePlotSyntax <- function(
         if (is.null(call_list$scale_x_continuous)) {
             call_list$scale_x_continuous <- list(
                 fun = ggplot2::scale_x_continuous,
-                args = list(breaks = xBreaks)
+                args = list(breaks = xBreaks, labels = numberLabels)
             )
         } else {
             call_list$scale_x_continuous$args$breaks <- xBreaks
+            call_list$scale_x_continuous$args$labels <- numberLabels
         }
     }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -391,25 +391,32 @@ autoscalePlotBreaks <- function(p, width_px, height_px) {
     xBreaks <- scales::breaks_pretty(n = nX)
     yBreaks <- scales::breaks_pretty(n = nY)
 
+    # scales::breaks_pretty() often lands on round powers of ten (e.g.
+    # 100000), which trips base R's format() into scientific notation for
+    # the whole axis. Label explicitly to keep breaks as plain numbers.
+    numberLabels <- scales::label_number(big.mark = "")
+
     xScaleExplicit <- p$scales$get_scales("x")
     yScaleExplicit <- p$scales$get_scales("y")
 
     if (!is.null(xScaleExplicit) && inherits(xScaleExplicit, "ScaleContinuousPosition")) {
         # Mutate in-place to preserve limits, name, etc.
         xScaleExplicit$breaks <- xBreaks
+        xScaleExplicit$labels <- numberLabels
     } else if (is.null(xScaleExplicit)) {
         pb <- ggplot2::ggplot_build(p)
         if (inherits(pb$layout$panel_scales_x[[1]], "ScaleContinuousPosition")) {
-            p <- p + ggplot2::scale_x_continuous(breaks = xBreaks)
+            p <- p + ggplot2::scale_x_continuous(breaks = xBreaks, labels = numberLabels)
         }
     }
 
     if (!is.null(yScaleExplicit) && inherits(yScaleExplicit, "ScaleContinuousPosition")) {
         yScaleExplicit$breaks <- yBreaks
+        yScaleExplicit$labels <- numberLabels
     } else if (is.null(yScaleExplicit)) {
         pb <- ggplot2::ggplot_build(p)
         if (inherits(pb$layout$panel_scales_y[[1]], "ScaleContinuousPosition")) {
-            p <- p + ggplot2::scale_y_continuous(breaks = yBreaks)
+            p <- p + ggplot2::scale_y_continuous(breaks = yBreaks, labels = numberLabels)
         }
     }
 

--- a/tests/testthat/helper-syntax-equivalence.R
+++ b/tests/testthat/helper-syntax-equivalence.R
@@ -59,6 +59,8 @@ expect_plot_equivalent <- function(res, data, renderFun) {
     pb <- bb$layout$panel_params[[1]]
     testthat::expect_equal(pb$x$breaks, pa$x$breaks, info = "x breaks")
     testthat::expect_equal(pb$y$breaks, pa$y$breaks, info = "y breaks")
+    testthat::expect_equal(pb$x$get_labels(), pa$x$get_labels(), info = "x labels")
+    testthat::expect_equal(pb$y$get_labels(), pa$y$get_labels(), info = "y labels")
 
     invisible(NULL)
 }

--- a/tests/testthat/testscat.R
+++ b/tests/testthat/testscat.R
@@ -192,6 +192,27 @@ testthat::test_that("scat syntax: grouped", {
     expect_plot_equivalent(res, df, ".scatterPlot")
 })
 
+testthat::test_that("scat syntax: large range avoids scientific notation axis labels", {
+    # GIVEN data whose x range produces round power-of-ten pretty breaks
+    # (github.com/jamovi/jamovi#1842: axis defaulted to scientific notation)
+    df <- data.frame(
+        x = c(631, 113000),
+        y = c(25.7, 78.1)
+    )
+    res <- scatr::scat(data = df, x = "x", y = "y")
+
+    # THEN the rendered plot's x-axis labels are plain numbers
+    jp <- jamoviGgplot(res, ".scatterPlot")
+    built <- suppressWarnings(ggplot2::ggplot_build(jp))
+    labels <- built$layout$panel_params[[1]]$x$get_labels()
+    labels <- labels[!is.na(labels)]
+    testthat::expect_true(length(labels) > 0)
+    testthat::expect_false(any(grepl("e[+-]", labels, ignore.case = TRUE)))
+
+    # AND the syntax mode output reproduces the same axis labels
+    expect_plot_equivalent(res, df, ".scatterPlot")
+})
+
 testthat::test_that("scat syntax: no error when required variables are missing", {
     # GIVEN an analysis with no variables assigned (jamovi's pre-data state)
     analysis <- scatr:::scatClass$new(

--- a/tests/testthat/testutils.R
+++ b/tests/testthat/testutils.R
@@ -1,0 +1,19 @@
+#' Autoscaled breaks avoid scientific notation
+testthat::test_that("autoscalePlotBreaks: avoids scientific notation for large round breaks", {
+    # GIVEN a scatter plot spanning a range whose pretty breaks include round
+    # powers of ten (e.g. 100000), which trips base R's format() into
+    # switching the whole axis to scientific notation
+    df <- data.frame(x = c(631, 113000), y = c(25.7, 78.1))
+    p <- ggplot2::ggplot(df, ggplot2::aes(x = x, y = y)) + ggplot2::geom_point()
+
+    # WHEN axis breaks are autoscaled for the panel size
+    p <- scatr:::autoscalePlotBreaks(p, width_px = 600, height_px = 400)
+
+    # THEN none of the x-axis tick labels use scientific notation
+    built <- ggplot2::ggplot_build(p)
+    labels <- built$layout$panel_params[[1]]$x$get_labels()
+    labels <- labels[!is.na(labels)]
+
+    testthat::expect_true(length(labels) > 0)
+    testthat::expect_false(any(grepl("e[+-]", labels, ignore.case = TRUE)))
+})


### PR DESCRIPTION
## Summary
Fixes jamovi/jamovi#1842. `scales::breaks_pretty()` (used by `autoscalePlotBreaks()` and the matching syntax-mode generator) often lands on round powers of ten, which trips base R's default label formatter into scientific notation for the whole axis. Both paths now set labels explicitly to keep breaks as plain numbers.

Stacked on #16 (ggplot2 syntax mode), since this fix touches the syntax-mode code path introduced there.

## Test plan
- [x] `testthat::test_dir("tests/testthat")` — 145 passed, 0 failed
- [x] New regression tests: direct unit test on `autoscalePlotBreaks()`, plus a scat end-to-end test reproducing the reported axis range
- [x] Strengthened `expect_plot_equivalent()` to also compare axis label text
- [x] `rcmdcheck` — 0 errors, 0 warnings